### PR TITLE
Avatar gap prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ export default YourComponent;
  `avatarBorderColors`       | string[]                                     | [DEFAULT_COLORS](#default-gradient-colors) | An array of string colors representing the border colors of story avatars.
  `avatarSeenBorderColors`   | string[]                                     | [ '#2A2A2C' ]                              | An array of string colors representing the border colors of seen story avatars.
  `avatarSize`               | number                                       | 60                                         | The size of the story avatars.
+ `avatarGap`                | number                                       | 0                                          | Gap size between the story avatars.
  `storyAvatarSize`          | number                                       | 25                                         | The size of the avatars shown in the header of each story.
  `listContainerStyle`       | ScrollViewProps['contentContainerStyle']     |                                            | Additional styles for the list container.
  `listContainerProps`       | ScrollViewProps                              |                                            | Props to be passed to the underlying ScrollView component.

--- a/src/components/Avatar/index.tsx
+++ b/src/components/Avatar/index.tsx
@@ -25,6 +25,7 @@ const StoryAvatar: FC<StoryAvatarProps> = ( {
   size,
   showName,
   nameTextStyle,
+  avatarGap,
 } ) => {
 
   const loaded = useSharedValue( false );
@@ -46,7 +47,7 @@ const StoryAvatar: FC<StoryAvatarProps> = ( {
   ) );
 
   return (
-    <View style={AvatarStyles.name}>
+    <View style={[AvatarStyles.name, { marginRight: avatarGap }]}>
       <View style={AvatarStyles.container}>
         <TouchableOpacity activeOpacity={0.6} onPress={onPress} testID={`${id}StoryAvatar${stories.length}Story`}>
           <Loader loading={isLoading} color={loaderColor} size={size + AVATAR_OFFSET * 2} />

--- a/src/components/InstagramStories/index.tsx
+++ b/src/components/InstagramStories/index.tsx
@@ -30,6 +30,7 @@ const InstagramStories = forwardRef<InstagramStoriesPublicMethods, InstagramStor
   videoAnimationMaxDuration,
   videoProps,
   closeIconColor = CLOSE_COLOR,
+  avatarGap = 0,
   ...props
 }, ref ) => {
 
@@ -218,6 +219,7 @@ const InstagramStories = forwardRef<InstagramStoriesPublicMethods, InstagramStor
             showName={showName}
             nameTextStyle={nameTextStyle}
             key={`avatar${story.id}`}
+            avatarGap={avatarGap}
           />
         ) )}
       </ScrollView>

--- a/src/core/dto/componentsDTO.ts
+++ b/src/core/dto/componentsDTO.ts
@@ -12,6 +12,7 @@ export interface StoryAvatarProps extends InstagramStoryProps {
   size: number;
   showName?: boolean;
   nameTextStyle?: TextStyle;
+  avatarGap?: number;
 }
 
 export interface StoryLoaderProps {

--- a/src/core/dto/instagramStoriesDTO.ts
+++ b/src/core/dto/instagramStoriesDTO.ts
@@ -43,6 +43,7 @@ export interface InstagramStoriesProps {
   onSwipeUp?: ( userId?: string, storyId?: string ) => void;
   onStoryStart?: ( userId?: string, storyId?: string ) => void;
   onStoryEnd?: ( userId?: string, storyId?: string ) => void;
+  avatarGap?: number;
 }
 
 export type InstagramStoriesPublicMethods = {


### PR DESCRIPTION
I found that the avatars are way too close together in the horizontal list, so I added a prop called avatarGap, which just adds a Right Margin to the Avatar component. Very simple way of allowing for a better layouting experience. 

I hope it is not a problem that I just skipped opening an issue and went straight into the contribution.