### PR TITLE
Move Story content outside animated view

### DIFF
--- a/src/components/List/index.tsx
+++ b/src/components/List/index.tsx
@@ -58,8 +58,8 @@ const StoryList: FC<StoryListProps> = ( {
           imageProps={imageProps}
           videoDuration={videoDuration}
         />
-        <StoryContent stories={stories} active={isActive} activeStory={activeStory} />
         <Animated.View style={[ contentStyles, ListStyles.content ]}>
+          <StoryContent stories={stories} active={isActive} activeStory={activeStory} />
           {imageOverlayView}
           <Progress
             active={isActive}

--- a/src/components/List/index.tsx
+++ b/src/components/List/index.tsx
@@ -58,6 +58,7 @@ const StoryList: FC<StoryListProps> = ( {
           imageProps={imageProps}
           videoDuration={videoDuration}
         />
+        <StoryContent stories={stories} active={isActive} activeStory={activeStory} />
         <Animated.View style={[ contentStyles, ListStyles.content ]}>
           {imageOverlayView}
           <Progress
@@ -70,7 +71,6 @@ const StoryList: FC<StoryListProps> = ( {
             progressContainerStyle={progressContainerStyle}
           />
           <StoryHeader {...props} />
-          <StoryContent stories={stories} active={isActive} activeStory={activeStory} />
         </Animated.View>
       </Animated.View>
       <StoryFooter stories={stories} active={isActive} activeStory={activeStory} />


### PR DESCRIPTION
renderContent was rendering content on top of everything, which included the progress indicators on top. Moving this above show the content beneath the progress indicator.