### PR TITLE
fix(story): imageOverlayView=> Overlay Buttons and Links Not Clickabl…

### DIFF
--- a/src/components/List/index.tsx
+++ b/src/components/List/index.tsx
@@ -58,9 +58,9 @@ const StoryList: FC<StoryListProps> = ( {
           imageProps={imageProps}
           videoDuration={videoDuration}
         />
-        <Animated.View style={[hideOverlayViewOnLongPress? contentStyles:{}, ListStyles.content ]}>
+        <Animated.View style={[hideOverlayViewOnLongPress ? contentStyles:{}, ListStyles.content ]} pointerEvents="auto">
           {imageOverlayView}
-          <Animated.View style={[contentStyles, ListStyles.content]}>
+          <Animated.View style={[contentStyles, ListStyles.content]} pointerEvents="box-none">
           <Progress
             active={isActive}
             activeStory={activeStoryIndex}


### PR DESCRIPTION
…e in Image/Video Story #104
due to this issue fix a previous issuse #[120](https://github.com/birdwingo/react-native-instagram-stories/issues/120) , the close issue [#104](https://github.com/birdwingo/react-native-instagram-stories/issues/104)  was regenerated ,that has been fixed in this PR 
