### PR TITLE
fix: pass seen property to renderAvatar

### DIFF
--- a/src/components/Avatar/index.tsx
+++ b/src/components/Avatar/index.tsx
@@ -26,15 +26,16 @@ const StoryAvatar: FC<StoryAvatarProps> = ( {
   showName,
   nameTextStyle,
   nameTextProps,
+  renderAvatar,
 } ) => {
 
   const loaded = useSharedValue( false );
   const isLoading = useDerivedValue( () => loadingStory.value === id || !loaded.value );
-  const loaderColor = useDerivedValue( () => (
-    seenStories.value[id] === stories[stories.length - 1]?.id
-      ? seenColors
-      : colors
-  ) );
+  const seen = useDerivedValue(
+    () => seenStories.value[id] === stories[stories.length - 1]?.id
+  );
+
+  const loaderColor = useDerivedValue(() => (seen.value ? seenColors : colors));
 
   const onLoad = () => {
 
@@ -45,6 +46,10 @@ const StoryAvatar: FC<StoryAvatarProps> = ( {
   const imageAnimatedStyles = useAnimatedStyle( () => (
     { opacity: withTiming( isLoading.value ? 0.5 : 1 ) }
   ) );
+
+  if (renderAvatar) return renderAvatar(seen.value);
+
+  if (!avatarSource) return null;
 
   return (
     <View style={AvatarStyles.name}>

--- a/src/components/Avatar/index.tsx
+++ b/src/components/Avatar/index.tsx
@@ -32,10 +32,9 @@ const StoryAvatar: FC<StoryAvatarProps> = ( {
   const loaded = useSharedValue( false );
   const isLoading = useDerivedValue( () => loadingStory.value === id || !loaded.value );
   const seen = useDerivedValue(
-    () => seenStories.value[id] === stories[stories.length - 1]?.id
+    () => seenStories.value[id] === stories[stories.length - 1]?.id,
   );
-
-  const loaderColor = useDerivedValue(() => (seen.value ? seenColors : colors));
+  const loaderColor = useDerivedValue( () => ( seen.value ? seenColors : colors ) );
 
   const onLoad = () => {
 
@@ -47,9 +46,17 @@ const StoryAvatar: FC<StoryAvatarProps> = ( {
     { opacity: withTiming( isLoading.value ? 0.5 : 1 ) }
   ) );
 
-  if (renderAvatar) return renderAvatar(seen.value);
+  if ( renderAvatar ) {
 
-  if (!avatarSource) return null;
+    return renderAvatar( seen.value );
+
+  }
+
+  if ( !avatarSource ) {
+
+    return null;
+
+  }
 
   return (
     <View style={AvatarStyles.name}>

--- a/src/components/AvatarList/index.tsx
+++ b/src/components/AvatarList/index.tsx
@@ -23,8 +23,7 @@ const StoryAvatarList: FC<StoryAvatarListProps> = ( {
   avatarListContainerProps, avatarListContainerStyle, onPress,
 } ) => {
 
-  const renderItem = ( story: InstagramStoryProps ) => story.renderAvatar?.()
-    ?? ( story.avatarSource && (
+  const renderItem = ( story: InstagramStoryProps ) => 
       <StoryAvatar
         {...story}
         loadingStory={loadingStory}
@@ -38,8 +37,8 @@ const StoryAvatarList: FC<StoryAvatarListProps> = ( {
         nameTextProps={nameTextProps}
         key={`avatar${story.id}`}
       />
-    ) );
-
+  ;
+  
   if ( FlashList ) {
 
     return (

--- a/src/components/AvatarList/index.tsx
+++ b/src/components/AvatarList/index.tsx
@@ -23,22 +23,22 @@ const StoryAvatarList: FC<StoryAvatarListProps> = ( {
   avatarListContainerProps, avatarListContainerStyle, onPress,
 } ) => {
 
-  const renderItem = ( story: InstagramStoryProps ) => 
-      <StoryAvatar
-        {...story}
-        loadingStory={loadingStory}
-        seenStories={seenStories}
-        onPress={() => onPress( story.id )}
-        colors={colors}
-        seenColors={seenColors}
-        size={size}
-        showName={showName}
-        nameTextStyle={nameTextStyle}
-        nameTextProps={nameTextProps}
-        key={`avatar${story.id}`}
-      />
-  ;
-  
+  const renderItem = ( story: InstagramStoryProps ) => (
+    <StoryAvatar
+      {...story}
+      loadingStory={loadingStory}
+      seenStories={seenStories}
+      onPress={() => onPress( story.id )}
+      colors={colors}
+      seenColors={seenColors}
+      size={size}
+      showName={showName}
+      nameTextStyle={nameTextStyle}
+      nameTextProps={nameTextProps}
+      key={`avatar${story.id}`}
+    />
+  );
+
   if ( FlashList ) {
 
     return (

--- a/src/core/dto/instagramStoriesDTO.ts
+++ b/src/core/dto/instagramStoriesDTO.ts
@@ -18,7 +18,7 @@ export interface StoryItemProps {
 export interface InstagramStoryProps {
   id: string;
   avatarSource: ImageProps['source'];
-  renderAvatar?: (seen: boolean) => ReactNode;
+  renderAvatar?: ( seen: boolean ) => ReactNode;
   renderStoryHeader?: () => ReactNode;
   onStoryHeaderPress?: () => void;
   name?: string;

--- a/src/core/dto/instagramStoriesDTO.ts
+++ b/src/core/dto/instagramStoriesDTO.ts
@@ -18,7 +18,7 @@ export interface StoryItemProps {
 export interface InstagramStoryProps {
   id: string;
   avatarSource: ImageProps['source'];
-  renderAvatar?: () => ReactNode;
+  renderAvatar?: (seen: boolean) => ReactNode;
   renderStoryHeader?: () => ReactNode;
   onStoryHeaderPress?: () => void;
   name?: string;


### PR DESCRIPTION
It would be quite useful to pass if a story has been seen or not to renderAvatar function when we want to render custom avatars, this is useful when we want to save progress and show custom avatars, at the moment we can render custom avatars but they don't know if the story has been seen. 

Its useful if we want to show something custom when a story has been seen. 

Raised issue [here](https://github.com/birdwingo/react-native-instagram-stories/issues/127)