### PR TITLE
Docs: udpate README to use avatarSource in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,11 +59,11 @@ const YourComponent = () => {
 
   // to use public methods:
   const ref = useRef( null ); // if using typescript - useRef<InstagramStoriesPublicMethods>( null )
-  
-  const stories = [{
+
+  const stories = [{ // if using typescript - const stories: InstagramStoriesProps['stories']
     id: 'user1',
     name: 'User 1',
-    imgUrl: 'user1-profile-image-url',
+    avatarSource: { uri: 'user1-profile-image-url', },
     stories: [
       { id: 'story1', source: { uri: 'story1-image-url' } },
       { id: 'story2', source: { uri: 'story1-video-url' }, mediaType: 'video' },


### PR DESCRIPTION
While trying the example I had an issue where the avatars were not visible after I realized the prop `imgUrl` does not exist anymore and now uses `avatarSource`.

So this PR updates the README example to also use `avatarSource` so the example works and people can just copy and paste to try out the lib