### PR TITLE
Fix: missing footerComponent type in instagramStoriesDTO

### DIFF
--- a/src/core/dto/instagramStoriesDTO.ts
+++ b/src/core/dto/instagramStoriesDTO.ts
@@ -61,6 +61,7 @@ export interface InstagramStoriesProps {
   hideOverlayViewOnLongPress?: boolean;
   loopingStories?: 'none' | 'all' | 'onlyLast';
   statusBarTranslucent?: boolean;
+  footerComponent?: ReactNode;
   onShow?: ( id: string ) => void;
   onHide?: ( id: string ) => void;
   onSwipeUp?: ( userId?: string, storyId?: string ) => void;


### PR DESCRIPTION
This PR adds the missing `footerComponent` type to `InstagramStoriesProps`.

**Context:**
The `footerComponent` prop was added to the `StoryModalProps` interface (#92) but missing on the `InstagramStoriesProps` interface which is the public component. 

So when trying to use the prop Typescript complains:
![Screenshot 2025-02-01 at 13 28 59](https://github.com/user-attachments/assets/6b21fd6a-fe4f-4ab4-8737-a05fdace7a2f)
