### PR TITLE
fix: imageProps type requiring source

### DIFF
--- a/src/core/dto/instagramStoriesDTO.ts
+++ b/src/core/dto/instagramStoriesDTO.ts
@@ -50,7 +50,7 @@ export interface InstagramStoriesProps {
   storyAnimationDuration?: number;
   mediaContainerStyle?: ViewStyle;
   imageStyles?: ImageStyle;
-  imageProps?: ImageProps;
+  imageProps?: Omit<ImageProps, 'source'>;
   isVisible?: boolean;
   headerStyle?: ViewStyle;
   headerContainerStyle?: ViewStyle;


### PR DESCRIPTION
**What**
This PR omits `source` from `imageProps`

**Why**
Not a big issue but is a little annoying having the `imageProps` showing an error because `source` is required in types.

![Screenshot 2025-03-08 at 12 35 29](https://github.com/user-attachments/assets/00a8c88a-c9d8-4777-84a0-87fde8ebbeb6)
