### PR TITLE
(suggestion) feat: expose paused value via ref

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,7 @@ export default YourComponent;
  `show`                | ( id?: string ) => void                                                                          | Show stories modal with provided story `id`. If `id` is not provided, will be shown first story
  `pause`               | () => void                                                                                       | Pause story
  `resume`              | () => void                                                                                       | Resume story
+ `isPaused`            | () => boolean                                                                                    | Returns true if story is paused
  `goToPreviousStory`   | () => void                                                                                       | Goes to previous story item
  `goToNextStory`       | () => void                                                                                       | Goes to next story item
  `getCurrentStory`     | () => {userId?: string, storyId?: string}                                                        | Returns current userId and storyId

--- a/src/components/InstagramStories/index.tsx
+++ b/src/components/InstagramStories/index.tsx
@@ -191,6 +191,7 @@ const InstagramStories = forwardRef<InstagramStoriesPublicMethods, InstagramStor
       },
       pause: () => modalRef.current?.pause()!,
       resume: () => modalRef.current?.resume()!,
+      isPaused: () => modalRef.current?.isPaused()!,
       goToPreviousStory: () => modalRef.current?.goToPreviousStory()!,
       goToNextStory: () => modalRef.current?.goToNextStory()!,
       getCurrentStory: () => modalRef.current?.getCurrentStory()!,

--- a/src/components/Modal/index.tsx
+++ b/src/components/Modal/index.tsx
@@ -423,6 +423,7 @@ const StoryModal = forwardRef<StoryModalPublicMethods, StoryModalProps>( ( {
       paused.value = false;
 
     },
+    isPaused: () => paused.value,
     getCurrentStory: () => ( { userId: userId.value, storyId: currentStory.value } ),
     goToPreviousStory: toPreviousStory,
     goToNextStory: toNextStory,

--- a/src/core/dto/componentsDTO.ts
+++ b/src/core/dto/componentsDTO.ts
@@ -78,6 +78,7 @@ export type StoryModalPublicMethods = {
   hide: () => void;
   pause: () => void;
   resume: () => void;
+  isPaused: () => boolean;
   goToPreviousStory: () => void;
   goToNextStory: () => void;
   getCurrentStory: () => { userId?: string, storyId?: string };


### PR DESCRIPTION
**What**
This PR adds a `isPaused` function to the Modal/InstagramStories ref public methods to expose the `paused` value.

**Why**
I was trying to create a pause/play button within a custom header but it had no way to get the current paused value.

> **Caevet:** exposing it has a ref method is not reactive but is enough for a simple play/pause implementation