### PR TITLE
fix: ensure header displays above content during loading state

### DIFF
--- a/src/components/List/List.styles.ts
+++ b/src/components/List/List.styles.ts
@@ -13,5 +13,6 @@ export default StyleSheet.create( {
     left: 0,
     bottom: 0,
     right: 0,
+    zIndex: 3,
   },
 } );

--- a/src/components/Progress/Progress.styles.ts
+++ b/src/components/Progress/Progress.styles.ts
@@ -8,7 +8,6 @@ export default StyleSheet.create( {
     height: 2,
     flexDirection: 'row',
     gap: 4,
-    zindex: 3,
   },
   item: {
     height: 3,


### PR DESCRIPTION
# Fix header z-index layering above loader

Fixes z-index issues introduced in #164 where header wasn't displaying properly above the loading overlay.

## Changes
- Move `zIndex: 3` from Progress.styles.ts to List.styles.ts container
- Fix `zindex` typo to `zIndex` 
- Ensure header displays above loader during loading state

## Issue
The previous loader customization PR placed z-index in the wrong component, causing header layering issues during loading states.

Related to #164